### PR TITLE
Add support for loading GIFTI surface files

### DIFF
--- a/library/voxeldepths_from_surfaces.py
+++ b/library/voxeldepths_from_surfaces.py
@@ -21,9 +21,17 @@ def load_fs_surf_in_grid(surf_file, grid_to_scanner, label_file=None):
     by using the grid_to_scanner transformation (e.g. affine function a functional nifti image).
     """
     # load freesurfer surface
-    coords, faces, volume_info = nib.freesurfer.read_geometry(
-        surf_file, read_metadata=True
-    )
+    fs_to_scanner = np.eye(4)
+    if surf_file[-4:] == ".gii":
+        surf_gii = nib.load(surf_file)
+        coords = surf_gii.agg_data("NIFTI_INTENT_POINTSET")
+        faces = surf_gii.agg_data("NIFTI_INTENT_TRIANGLE")
+        volume_info = {"cras": np.array([0.0, 0.0, 0.0])}
+    else:
+     # load freesurfer surface
+        coords, faces, volume_info = nib.freesurfer.read_geometry(
+            surf_file, read_metadata=True
+        )
 
     # if label file provided
     if label_file is not None:


### PR DESCRIPTION
This should make vdfs work with gii surfaces, while keeping compatibility with fs surfaces. Volume info is initiated empty, which works assuming the surfaces are already in voxel space, which they should be following previous steps from the pipeline. # # #13 